### PR TITLE
Added Missing (?) Bool Negation

### DIFF
--- a/Core/Source/DTBonjourDataConnection.m
+++ b/Core/Source/DTBonjourDataConnection.m
@@ -171,7 +171,7 @@ typedef enum
       // streams see the `QNetworkAdditions` above. (If the delegate does not
       // implement the `kDTBonjourQNetworkAdditionsCheck` selector, we can
       // simply use the patched version.
-      if ([service qNetworkAdditions_getInputStream:&in outputStream:&out])
+      if (![service qNetworkAdditions_getInputStream:&in outputStream:&out])
         return nil;
     }
     else


### PR DESCRIPTION
`qNetworkAdditions_getInputStream` returns `YES` if streams were created successfully. Consequently, `initWithService` should return NIL when `NO` (=something wrong with streams) is returned. 
