### PR TITLE
Fix issues with system generated service name.

### DIFF
--- a/Core/Source/DTBonjourServer.m
+++ b/Core/Source/DTBonjourServer.m
@@ -209,7 +209,7 @@ static void ListeningSocketCallback(CFSocketRef s, CFSocketCallBackType type, CF
 	}
 	
 	assert(self.port > 0 && self.port < 65536);
-	_service = [[NSNetService alloc] initWithDomain:@"" type:_bonjourType name:@"" port:(int)_port];
+    _service = [[NSNetService alloc] initWithDomain:@"" type:_bonjourType name:[[NSUUID UUID] UUIDString] port:(int)_port];
 	_service.delegate = self;
 	
 	if (_TXTRecord)
@@ -373,7 +373,14 @@ static void ListeningSocketCallback(CFSocketRef s, CFSocketCallBackType type, CF
 
 - (void)netServiceDidPublish:(NSNetService *)sender
 {
-	NSLog(@"My name: %@ port: %d", [sender name], (int)sender.port);
+
+//    NSDictionary *dict = [NSNetService dictionaryFromTXTRecordData:sender.TXTRecordData];
+//    NSString *roomName = [[NSString alloc] initWithData:dict[@"RoomName"] encoding:NSUTF8StringEncoding];
+//    NSString *identifier = [[NSString alloc] initWithData:dict[@"ID"] encoding:NSUTF8StringEncoding];
+//    
+//    NSLog(@"My name: %@ port: %d roomName:%@ identifier:%@", [sender name], (int)sender.port, roomName, identifier);
+    
+    NSLog(@"My name: %@ port: %d", [sender name], (int)sender.port);
 }
 
 - (void)netServiceDidStop:(NSNetService *)sender


### PR DESCRIPTION
In start method of DTBonjourServer.m I now initialize NSNetService with a UUID for the name instead of @"" which lets the system choose a name based on the computer name.

UUID is obtained with [[NSUUID UUID] UUIDString]

When I allowed the system to choose a name, and multiple servers were started, I saw names such as:
iPhone 6 plus
iPhone 6 plus (2)
etc.

I saw 2 problems when using the system assigned names.   My test case was the BonjourChat example as referenced at:
https://www.cocoanetics.com/2012/11/and-bonjour-to-you-too/
https://github.com/Cocoanetics/Examples/tree/master/BonjourChat

1. The NetServiceBrowser on the client would sometimes find the same txt record for 2 different connections (different service names).  It would only occur after the servers were stopped and restarted (background and foreground host app).

2. The servers would be slow to create connections after stopping and restarting.

After switching to a UUID for the service name, both of these issues were resolved.